### PR TITLE
allow setting root via env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,14 @@ have been logged anyway.
 
 const debug = require('debug')
 
-// This is the directory from which node process was launched.
-// We use it as root since it gives relative paths which can be clicked on
-// (in terminals such as iTerm) to open the file in an editor.
-const cwd = process.cwd()
+// This is a string, or a regex, which will be matched against the __filename.
+// Whatever it matches will be removed.
+const root =
+  process.env.DVF_LOGGER_ROOT ||
+  // This is the directory from which node process was launched.
+  // We use it as default root since it gives relative paths which can be
+  // clicked on (in terminals such as iTerm) to open the file in an editor.
+  `${process.cwd()}/`
 
 expandThunks = (array) => array.map(
   elem => typeof elem == 'function' ? elem() : elem
@@ -95,14 +99,16 @@ makeStrictLogger = (label, {logToStderr, isErrorLogger}) => {
   return logger
 }
 
-module.exports = function (filename, options = {}) {
+module.exports = function (filename, options = { root }) {
   const {
     prefix = 'dvf',
-    root = cwd,
+    root,
     logToStderr = false
   } = options
 
-  const relativeFilePath = filename.replace(new RegExp(`^${root}/`), '');
+  console.log('root', root)
+
+  const relativeFilePath = filename.replace(new RegExp(`^${root}`), '');
 
   const errorOptions = Object.assign({}, options, {
     logToStderr: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "a thin wrapper around debug module",
   "main": "index.js",
   "repository": "git@github.com:DeversiFi/logger.git",


### PR DESCRIPTION
root parameter is used to remove unnecesary prefix from filepath
before using it as log label

for example:
  given:
    filepath = /home/me/code/some_repo/src/server.js
    root = /home/me/code/some_repo/

  each log will include: src/server.js

root can be also a regex for cases where the exact path is now known

note: most of the time the default, base on process.cwd, is sufficient
however starting the application from a directory different then the
source repos root it is not and hence we allow root to be configured
manually

This can be used to fix the long paths logged in one of our services which is built with nix, where the application resides in the /nix/store but is started from the home dir 