### PR TITLE
Standardize logging formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,9 +123,22 @@ const formatData = (data) => {
     return data
 }
 
+const invalidInvocation = (args, extraTypesForMessage) => {
+  console.error(new Error('INVALID_LOG_INVOCATION'))
+  return parseArgs(args, extraTypesForMessage)
+}
+
 const parseArgsV2 = (args, extraTypesForMessage) => {
-  if (args.length == 1 || args.length > 2) {
-    return parseArgs(args, extraTypesForMessage)
+  if (args.length == 1) {
+    if (typeof args[0] == 'string') {
+      return {
+        message: args[0]
+      }
+    } else {
+      return invalidInvocation(args, extraTypesForMessage)
+    }
+  } else if (args.length > 2) {
+    return invalidInvocation(args, extraTypesForMessage)
   }
 
   // Standard log format, [message, data]

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ const formatData = (data) => {
   if (simpleTypes.includes(typeof data)) 
     return `${stringifySimple(data)}`
 
-  if (typeof data == 'object')
+  if (typeof data === 'object')
     return data
 }
 
@@ -130,7 +130,7 @@ const invalidInvocation = (args, extraTypesForMessage) => {
 
 const parseArgsV2 = (args, extraTypesForMessage) => {
   if (args.length == 1) {
-    if (typeof args[0] == 'string') {
+    if (typeof args[0] === 'string') {
       return {
         message: args[0]
       }

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ const parseArgs = (args, extraTypesForMessage) => {
   const data = args
     .map((arg) => {
       if (simpleTypes.includes(typeof arg)) {
-        message += `${stringifySimple(arg, DEPTH)}`
+        message += `${stringifySimple(arg)}`
       } else if (arg instanceof Error) {
         if (!message) {
           message = arg.message
@@ -117,7 +117,7 @@ const parseArgs = (args, extraTypesForMessage) => {
 
 const formatData = (data) => {
   if (simpleTypes.includes(typeof data)) 
-    return `${stringifySimple(data, DEPTH)}`
+    return `${stringifySimple(data)}`
 
   if (typeof data == 'object')
     return data

--- a/index.js
+++ b/index.js
@@ -162,6 +162,13 @@ const parseArgsV2 = (args, extraTypesForMessage) => {
   }
 }
 
+/**
+ * 
+ * @param {string} severity 
+ * @param {string} context 
+ * @param {Object} extraTypesForMessage 
+ * @returns {(message: string, data?: Object | Error) => void}
+ */
 const makeStrictLogger = (severity, context, extraTypesForMessage) => {
   const debugLogger = debug(`dvf:${severity}:${context}`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-logger",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "a thin wrapper around debug module",
   "main": "index.js",
   "repository": "git@github.com:DeversiFi/logger.git",

--- a/test.js
+++ b/test.js
@@ -38,3 +38,7 @@ logger.emergency(
     }
   }
 )
+
+// Valid logs
+logger.log('Some message', { id1: 'id1', id2: 'id2', nestedProp: { id3: 'id3' } })
+logger.error('Some error occured', new Error('some error'))


### PR DESCRIPTION
Standardize logging to support a uniform interface: `log(message, data)` where data can be any type or `Error` object

Examples from tests, note that only the last two lines are following the 2 arg format:

```sh
{"severity": "ERROR", "timestamp": 1649324342102, "context": "/home/arman/dev/dvf-logger/test.js", "message": "Only Error", "data": [{"name": "Error", "message": "Only Error", "data": null, "stack": "Error: Only Error\n    at Object.<anonymous> (/home/arman/dev/dvf-logger/test.js:7:14)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)\n    at internal/main/run_main_module.js:17:47"}], "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "DEBUG", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "Debug messagetrue {}123", "data": [{"field1": "stuff"}, {}], "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "LOG", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "some information here", "data": [{"field1": "stuff"}, {"field1": "more stuff"}], "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "WARN", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "warning, attention | what?", "error": {"name": "Error", "message": "what?", "data": null, "stack": "Error: what?\n    at Object.<anonymous> (/home/arman/dev/dvf-logger/test.js:13:35)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)\n    at internal/main/run_main_module.js:17:47"}, "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "ERROR", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "error, not good | some pretty looking stack trace", "error": {"name": "Error", "message": "some pretty
looking stack trace", "data": null, "stack": "Error: some pretty looking stack trace\n    at Object.<anonymous> (/home/arman/dev/dvf-logger/test.js:14:33)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)\n    at internal/main/run_main_module.js:17:47"}, "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "EMERGENCY", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "uh oh, its an emergency {}true421", "data": [{}, [{"fillAmount": -420, "fee": 23000000000}, 4512, true], {"name": "Error", "message": "FUNDS_ARE_SAFU", "data": null, "stack": "Error: FUNDS_ARE_SAFU\n    at Object.<anonymous> (/home/arman/dev/dvf-logger/test.js:21:3)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)\n    at internal/main/run_main_module.js:17:47"}, {"level1": {"level2": {"level3": "{ ? }"}}}], "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "LOG", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "Some message", "data": {"id1": "id1", "id2": "id2", "nestedProp": {"id3": "id3"}}, "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}
{"severity": "ERROR", "timestamp": 1649324342103, "context": "/home/arman/dev/dvf-logger/test.js", "message": "Some error occured | some error", "error": {"name": "Error", "message": "some error", "data": null, "stack": "Error: some error\n    at Object.<anonymous> (/home/arman/dev/dvf-logger/test.js:44:36)\n    at Module._compile (internal/modules/cjs/loader.js:999:30)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)\n    at Module.load (internal/modules/cjs/loader.js:863:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:708:14)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)\n    at internal/main/run_main_module.js:17:47"}, "logging.googleapis.com/sourceLocation": {"file": "/home/arman/dev/dvf-logger/test.js"}}

```